### PR TITLE
feat: Use ExchangeRate-API for USD to CAD conversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,10 @@ build:
 	mkdir -p dist
 	cp -R tmpl/css dist
 	minijinja-cli tmpl/index.html.j2 \
-		-D "rate=$(shell rates 1 USD to CAD --short)" > dist/index.html
+		-D "rate=$(shell curl -s 'https://api.exchangerate-api.com/v4/latest/USD' | jq '.rates.CAD')" > dist/index.html
 
 install:
 	cargo install \
-		minijinja-cli \
-		rates
+		minijinja-cli
 
 .PHONY: build install


### PR DESCRIPTION
This commit changes the method for fetching the USD to CAD exchange rate. It replaces the 'rates' CLI tool with a combination of 'curl' to fetch data from ExchangeRate-API and 'jq' to parse the JSON response.

The Makefile has been updated accordingly, including the removal of the 'rates' tool from the install dependencies.