### PR TITLE
feat: Add adaptive light/dark mode via separate theme.css

### DIFF
--- a/tmpl/css/theme.css
+++ b/tmpl/css/theme.css
@@ -1,0 +1,55 @@
+:root {
+    --background-color: #fff;
+    --text-color: #222;
+    --link-color: #007bff;
+    --link-hover-color: #0056b3;
+}
+
+[data-theme="dark"] {
+    --background-color: #222;
+    --text-color: #fff;
+    --link-color: #64b5f6;
+    --link-hover-color: #2196f3;
+}
+
+html {
+    color: var(--text-color);
+    background-color: var(--background-color);
+}
+
+body {
+    background-color: var(--background-color);
+    color: var(--text-color);
+}
+
+.content {
+    color: var(--text-color); /* Ensure content text uses theme color */
+}
+
+/* Basic link styling using CSS variables */
+a {
+    color: var(--link-color);
+    text-decoration: none;
+}
+
+a:hover {
+    color: var(--link-hover-color);
+    text-decoration: underline;
+}
+
+/* Ensure print styles also respect theme colors where appropriate */
+@media print {
+    body {
+        background: #fff !important; /* Typically print on white */
+        color: #000 !important;
+    }
+
+    a,
+    a:visited {
+        color: var(--link-color) !important;
+    }
+
+    .content {
+        color: #000 !important; /* Content text black for printing */
+    }
+}

--- a/tmpl/index.html.j2
+++ b/tmpl/index.html.j2
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Montreal</title>
   <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="css/theme.css">
   <meta name="description" content="A website that puts the USD → CAD exchange rate front-and-center.">
 </head>
 
@@ -15,6 +16,13 @@
     <h1>1 USD → {{ rate }} CAD</h1>
   </div>
 
+  <script>
+    (function() {
+      const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const theme = prefersDark ? 'dark' : 'light';
+      document.documentElement.setAttribute('data-theme', theme);
+    })();
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
Implement an adaptive light/dark mode that defaults to the user's browser/OS preference.

- Created a new `tmpl/css/theme.css` to house all theme-specific CSS, leaving the vendored `style.css` untouched.
- Defined CSS variables for theming (light and dark) in `theme.css`.
- Linked `theme.css` in `tmpl/index.html.j2` after the original stylesheet.
- Included a JavaScript snippet to detect OS theme preference and apply the corresponding theme on page load by setting a `data-theme` attribute.